### PR TITLE
custom css templates + hi-res display support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ format: String, image format, 'png' or 'jpg', Default is 'png'
 
 processor: String, css processor, 'css' or 'less' or 'sass' or 'scss', Default is 'css'
 
-retina: Boolean, returns higher quality image, Default is false
+dotsPerPixel: Number, dots per px unit, used for sharper images, Default is 1
 
 opacity: Number, 0 - 1, Default is 0
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ imgPath: String, path to sprites output dir.
 
 cssPath: String, path to sprites stylesheets output dir.
 
-templatePath: String, path to customized template dir.
+templatePath: String, full path to custom template. (Optional)
 
 prefix: String, the prefix of sprites classname, Default is 'icon'
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ imgPath: String, path to sprites output dir.
 
 cssPath: String, path to sprites stylesheets output dir.
 
+templatePath: String, path to customized template dir.
+
 prefix: String, the prefix of sprites classname, Default is 'icon'
 
 connector: String, 'dash' or 'underline', Default is 'dash'
@@ -69,6 +71,8 @@ orientation: String, 'vertical' or 'horizontal', Default is 'vertical'
 format: String, image format, 'png' or 'jpg', Default is 'png'
 
 processor: String, css processor, 'css' or 'less' or 'sass' or 'scss', Default is 'css'
+
+retina: Boolean, returns higher quality image, Default is false
 
 opacity: Number, 0 - 1, Default is 0
 

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ module.exports = {
   cssPath: process.cwd() + '/styles/',
   imgPath: process.cwd() + '/images/',
   processor: 'css',
+  templatePath: process.cwd() + '/templates/',
   opacity: 0,
   prefix: 'icon',
   useImport: false,

--- a/config.js
+++ b/config.js
@@ -9,7 +9,6 @@ module.exports = {
   cssPath: process.cwd() + '/styles/',
   imgPath: process.cwd() + '/images/',
   processor: 'css',
-  templatePath: process.cwd() + '/templates/',
   opacity: 0,
   prefix: 'icon',
   useImport: false,

--- a/config.js
+++ b/config.js
@@ -14,5 +14,5 @@ module.exports = {
   useImport: false,
   indexName: 'index',
   bundleMode: 'one',
-  retina: false
+  dotsPerPixel: 1
 };

--- a/config.js
+++ b/config.js
@@ -13,5 +13,6 @@ module.exports = {
   prefix: 'icon',
   useImport: false,
   indexName: 'index',
-  bundleMode: 'one'
+  bundleMode: 'one',
+  retina: false
 };

--- a/lib/sprite-webpack.js
+++ b/lib/sprite-webpack.js
@@ -143,10 +143,10 @@ function getStyles() {
       var name = duplicateClassname(classnames, classname, newClassName);
       styles.push({
         'name':   name,
-        'x':      item.x / opts.dppx,
-        'y':      item.y / opts.dppx,
-        'width':  item.width / opts.dppx,
-        'height': item.height / opts.dppx
+        'x':      item.x / opts.dotsPerPixel,
+        'y':      item.y / opts.dotsPerPixel,
+        'width':  item.width / opts.dotsPerPixel,
+        'height': item.height / opts.dotsPerPixel
       });
     });
     return templater({
@@ -162,8 +162,8 @@ function getStyles() {
           'connector': opts.connector,
           'processor': opts.processor,
           'templatePath': opts.templatePath,
-          'spriteWidth': opts.info.width / opts.dppx,
-          'spriteHeight': opts.info.height / opts.dppx
+          'spriteWidth': opts.info.width / opts.dotsPerPixel,
+          'spriteHeight': opts.info.height / opts.dotsPerPixel
         }
       }
     );

--- a/lib/sprite-webpack.js
+++ b/lib/sprite-webpack.js
@@ -143,10 +143,10 @@ function getStyles() {
       var name = duplicateClassname(classnames, classname, newClassName);
       styles.push({
         'name':   name,
-        'x':      item.x,
-        'y':      item.y,
-        'width':  item.width,
-        'height': item.height
+        'x':      opts.retina ? item.x / 2 : item.x,
+        'y':      opts.retina ? item.y / 2 : item.y,
+        'width':  opts.retina ? item.width / 2 : item.width,
+        'height': opts.retina ? item.height / 2 : item.height
       });
     });
     return templater({
@@ -161,7 +161,9 @@ function getStyles() {
           'cssClass': opts.prefix,
           'connector': opts.connector,
           'processor': opts.processor,
-          'templatePath': opts.templatePath
+          'templatePath': opts.templatePath,
+          'spriteWidth': opts.retina ? opts.info.width / 2 : opts.info.width,
+          'spriteHeight': opts.retina ? opts.info.height / 2 : opts.info.height
         }
       }
     );

--- a/lib/sprite-webpack.js
+++ b/lib/sprite-webpack.js
@@ -160,7 +160,8 @@ function getStyles() {
         formatOpts: {
           'cssClass': opts.prefix,
           'connector': opts.connector,
-          'processor': opts.processor
+          'processor': opts.processor,
+          'templatePath': opts.templatePath
         }
       }
     );

--- a/lib/sprite-webpack.js
+++ b/lib/sprite-webpack.js
@@ -143,10 +143,10 @@ function getStyles() {
       var name = duplicateClassname(classnames, classname, newClassName);
       styles.push({
         'name':   name,
-        'x':      opts.retina ? item.x / 2 : item.x,
-        'y':      opts.retina ? item.y / 2 : item.y,
-        'width':  opts.retina ? item.width / 2 : item.width,
-        'height': opts.retina ? item.height / 2 : item.height
+        'x':      item.x / opts.dppx,
+        'y':      item.y / opts.dppx,
+        'width':  item.width / opts.dppx,
+        'height': item.height / opts.dppx
       });
     });
     return templater({
@@ -162,8 +162,8 @@ function getStyles() {
           'connector': opts.connector,
           'processor': opts.processor,
           'templatePath': opts.templatePath,
-          'spriteWidth': opts.retina ? opts.info.width / 2 : opts.info.width,
-          'spriteHeight': opts.retina ? opts.info.height / 2 : opts.info.height
+          'spriteWidth': opts.info.width / opts.dppx,
+          'spriteHeight': opts.info.height / opts.dppx
         }
       }
     );

--- a/lib/templates/sprite.js
+++ b/lib/templates/sprite.js
@@ -24,9 +24,7 @@ function cssTemplate (params) {
     template.items.push(item);
   });
 
-  var tmplFile = readTemplate[options.processor, options.templatePath];
-  console.log(options.templatePath);
-  console.log(tmplFile);
+  var tmplFile = readTemplate(options.processor, options.templatePath);
   var css = mustache.render(tmplFile, template);
   return css;
 }

--- a/lib/templates/sprite.js
+++ b/lib/templates/sprite.js
@@ -7,9 +7,9 @@ var cssesc = require('cssesc');
 
 function readTemplate(processor, templatePath) {
   if (!templatePath) {
-    templatePath = __dirname;
+    templatePath = __dirname + '/' + processor + '.mustache';
   }
-  return fs.readFileSync(templatePath + '/' + processor + '.mustache', 'utf8');
+  return fs.readFileSync(templatePath, 'utf8');
 }
 
 function cssTemplate (params) {

--- a/lib/templates/sprite.js
+++ b/lib/templates/sprite.js
@@ -4,13 +4,10 @@ var fs = require('fs');
 var path = require('path');
 var mustache = require('mustache');
 var cssesc = require('cssesc');
-var tmpl = {
-  'css': fs.readFileSync(__dirname + '/css.mustache', 'utf8'),
-  'scss': fs.readFileSync(__dirname + '/scss.mustache', 'utf8'),
-  'sass': fs.readFileSync(__dirname + '/sass.mustache', 'utf8'),
-  'less': fs.readFileSync(__dirname + '/less.mustache', 'utf8'),
-  'stylus': fs.readFileSync(__dirname + '/stylus.mustache', 'utf8')
-};
+
+function readTemplate(processor, templatePath) {
+  return fs.readFileSync(templatePath + '/' + processor + '.mustache', 'utf8');
+}
 
 function cssTemplate (params) {
   var items = params.items;
@@ -27,7 +24,9 @@ function cssTemplate (params) {
     template.items.push(item);
   });
 
-  var tmplFile = tmpl[options.processor];
+  var tmplFile = readTemplate[options.processor, options.templatePath];
+  console.log(options.templatePath);
+  console.log(tmplFile);
   var css = mustache.render(tmplFile, template);
   return css;
 }

--- a/lib/templates/sprite.js
+++ b/lib/templates/sprite.js
@@ -6,6 +6,9 @@ var mustache = require('mustache');
 var cssesc = require('cssesc');
 
 function readTemplate(processor, templatePath) {
+  if (!templatePath) {
+    templatePath = __dirname;
+  }
   return fs.readFileSync(templatePath + '/' + processor + '.mustache', 'utf8');
 }
 
@@ -23,6 +26,9 @@ function cssTemplate (params) {
     };
     template.items.push(item);
   });
+
+  template.sprite_width = options.spriteWidth;
+  template.sprite_height =  options.spriteHeight;
 
   var tmplFile = readTemplate(options.processor, options.templatePath);
   var css = mustache.render(tmplFile, template);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprite-webpack-plugin",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "sprite-webpack-plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR provides the ability to specify a templatePath, where the plugin will look for custom CSS templates. It also adds a "dotsPerPixel" option, which causes all of the image sizes and coordinates to be divided by that number. This allows us to use higher-resolution sprite images which look better on hi-res displays.
