### PR TITLE
update dependency 'lwip' for Node 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "imageinfo": "^1.0.4",
     "layout": "^2.2.0",
     "lodash": "^3.10.1",
-    "lwip": "0.0.8",
+    "lwip": "0.0.9",
     "mkdirp": "^0.5.1",
     "mustache": "^2.1.3",
     "spritesheet-templates": "^10.0.0"


### PR DESCRIPTION
HI, @kezoo. Because of 'lwip' dependency , I couldn't install this plugin with Node 6.x - https://github.com/EyalAr/lwip/issues/249 and plz update the dependency or merge my PR. Thanks.
